### PR TITLE
Add the command migrate-libs 

### DIFF
--- a/interfaces/migrate/src/main/java/migrate/interfaces/Lib.java
+++ b/interfaces/migrate/src/main/java/migrate/interfaces/Lib.java
@@ -1,0 +1,9 @@
+package migrate.interfaces;
+
+public interface Lib {
+    String getOrganization();
+    String getName();
+    String getRevision();
+    String getCrossVersion();
+    String toString();
+}

--- a/interfaces/migrate/src/main/java/migrate/interfaces/Migrate.java
+++ b/interfaces/migrate/src/main/java/migrate/interfaces/Migrate.java
@@ -12,6 +12,7 @@ import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Map;
 import java.util.List;
 
 public interface Migrate {
@@ -26,6 +27,7 @@ public interface Migrate {
                  Path scala3ClassDirectory);
     
     ScalacOptions migrateScalacOption(List<String> scala3CompilerOptions);
+    Map<Lib, List<Lib>> migrateLibs(List<Lib> libs);
 
     void prepareMigration(List<Path> unmanagedSources,
                  Path targetRoot,

--- a/migrate/src/main/scala/migrate/LibToMigrate.scala
+++ b/migrate/src/main/scala/migrate/LibToMigrate.scala
@@ -60,21 +60,13 @@ case class CompatibleWithScala3Lib(
 object LibToMigrate {
   case class Organization(value: String)
   case class Name(value: String)
-  case class Revision(value: String) extends Ordered[Revision] {
-    override def compare(that: Revision): Int =
-      Revision.ordering.compare(this, that)
+  case class Revision(value: String) {
     private val version: Seq[String] = value.split('.')
     val major: Option[Int]           = version.headOption.flatMap(v => Try(v.toInt).toOption)
     val minor: Option[Int]           = Try(version(1).toInt).toOption
     val patch: Option[Int]           = Try(version(2).split("-")(0).toInt).toOption
     val beta: Option[String]         = Try(version(2).split("-")(1)).toOption
 
-  }
-  object Revision {
-    implicit val ordering: Ordering[Revision] =
-      Ordering.by[Revision, (Option[Int], Option[Int], Option[Int], Option[String])] { x: Revision =>
-        (x.major, x.minor, x.patch, x.beta)
-      }
   }
   sealed trait CrossVersion {
     override def toString: String = this match {

--- a/migrate/src/main/scala/migrate/LibToMigrate.scala
+++ b/migrate/src/main/scala/migrate/LibToMigrate.scala
@@ -1,0 +1,143 @@
+package migrate
+
+import scala.util.Try
+
+import migrate.Lib213.macroLibs
+import migrate.LibToMigrate._
+import migrate.interfaces.Lib
+import migrate.utils.CoursierHelper
+
+sealed trait LibToMigrate extends Lib {
+  val organization: Organization
+  val name: Name
+  val revision: Revision
+  val crossVersion: CrossVersion
+
+  override def getOrganization: String = organization.value
+  override def getName: String         = name.value
+  override def getRevision: String     = revision.value
+  override def getCrossVersion: String = crossVersion.toString
+
+  override def toString: String = s"${organization.value}:${name.value}:${revision.value}"
+
+}
+
+case class Lib213(organization: Organization, name: Name, revision: Revision, crossVersion: CrossVersion)
+    extends LibToMigrate {
+  def toCompatible: Seq[CompatibleWithScala3Lib] =
+    crossVersion match {
+      // keep the same if CrossVersion.Disabled. Usually it's a Java Lib
+      case CrossVersion.Disabled => Seq(CompatibleWithScala3Lib.from(this))
+      // look for revisions that are compatible with scala 3 binary version
+      case CrossVersion.Binary(_, _) => getCompatibleWhenBinaryCrossVersion()
+      // look for revisions that are compatible with scala 3 full version
+      case CrossVersion.Full(_, _) => CoursierHelper.getCompatibleForScala3Full(this)
+      // already compatible
+      case CrossVersion.For2_13Use3(_, _) => Seq(CompatibleWithScala3Lib.from(this))
+      case CrossVersion.For3Use2_13(_, _) => Seq(CompatibleWithScala3Lib.from(this))
+      // For Patch and Constant, we search full compatible scala 3 version
+      case CrossVersion.Patch       => CoursierHelper.getCompatibleForScala3Full(this)
+      case CrossVersion.Constant(_) => CoursierHelper.getCompatibleForScala3Full(this)
+    }
+
+  private def getCompatibleWhenBinaryCrossVersion(): Seq[CompatibleWithScala3Lib] = {
+    val scala3Libs = CoursierHelper.getCompatibleForScala3Binary(this)
+    if (scala3Libs.isEmpty) {
+      if (macroLibs.get(this.organization).contains(this.name)) Nil
+      else CoursierHelper.getCompatibleForBinary213(this)
+    } else scala3Libs
+  }
+
+}
+
+case class CompatibleWithScala3Lib(
+  organization: Organization,
+  name: Name,
+  revision: Revision,
+  crossVersion: CrossVersion
+) extends LibToMigrate
+
+object LibToMigrate {
+  case class Organization(value: String)
+  case class Name(value: String)
+  case class Revision(value: String) extends Ordered[Revision] {
+    override def compare(that: Revision): Int =
+      Revision.ordering.compare(this, that)
+    private val version: Seq[String] = value.split('.')
+    val major: Option[Int]           = version.headOption.flatMap(v => Try(v.toInt).toOption)
+    val minor: Option[Int]           = Try(version(1).toInt).toOption
+    val patch: Option[Int]           = Try(version(2).split("-")(0).toInt).toOption
+    val beta: Option[String]         = Try(version(2).split("-")(1)).toOption
+
+  }
+  object Revision {
+    implicit val ordering: Ordering[Revision] =
+      Ordering.by[Revision, (Option[Int], Option[Int], Option[Int], Option[String])] { x: Revision =>
+        (x.major, x.minor, x.patch, x.beta)
+      }
+  }
+  sealed trait CrossVersion {
+    override def toString: String = this match {
+      case CrossVersion.Binary(prefix: String, suffix: String)      => s"Binary($prefix, $suffix)"
+      case CrossVersion.Disabled                                    => "Disabled()"
+      case CrossVersion.Constant(value: String)                     => s"Constant($value)"
+      case CrossVersion.Patch                                       => "Patch()"
+      case CrossVersion.Full(prefix: String, suffix: String)        => s"Full($prefix, $suffix)"
+      case CrossVersion.For3Use2_13(prefix: String, suffix: String) => s"For3Use2_13($prefix, $suffix)"
+      case CrossVersion.For2_13Use3(prefix: String, suffix: String) => s"For3Use2_13($prefix, $suffix)"
+    }
+  }
+
+  object CrossVersion {
+    case class Binary(prefix: String, suffix: String)      extends CrossVersion
+    case object Disabled                                   extends CrossVersion
+    case class Constant(value: String)                     extends CrossVersion
+    case object Patch                                      extends CrossVersion
+    case class Full(prefix: String, suffix: String)        extends CrossVersion
+    case class For3Use2_13(prefix: String, suffix: String) extends CrossVersion
+    case class For2_13Use3(prefix: String, suffix: String) extends CrossVersion
+
+    def from(value: String): Option[CrossVersion] =
+      value match {
+        case "Disabled()"                     => Some(Disabled)
+        case s"Binary($prefix, $suffix)"      => Some(Binary(prefix, suffix))
+        case s"Constant($value)"              => Some(Constant(value))
+        case "Patch()"                        => Some(Patch)
+        case s"Full($prefix, $suffix)"        => Some(Full(prefix, suffix))
+        case s"For3Use2_13($prefix, $suffix)" => Some(For3Use2_13(prefix, suffix))
+        case s"For3Use2_13($prefix, $suffix)" => Some(For2_13Use3(prefix, suffix))
+        case _                                => None
+      }
+  }
+}
+
+object Lib213 {
+  def from(lib: migrate.interfaces.Lib): Option[Lib213] = {
+    val organization = Organization(lib.getOrganization)
+    val name         = Name(lib.getName)
+    val revision     = Revision(lib.getRevision)
+    val crossVersion = CrossVersion.from(lib.getCrossVersion)
+    crossVersion.map(c => Lib213(organization, name, revision, c))
+  }
+
+  def from(value: String, crossVersion: CrossVersion): Option[Lib213] = {
+    val splited = value.split(":").toList
+    splited match {
+      case (org :: name :: revision :: Nil) =>
+        Some(Lib213(Organization(org), Name(name), Revision(revision), crossVersion))
+      case _ => None
+    }
+  }
+
+  val macroLibs: Map[Organization, Name] =
+    // need to complete the list
+    Map(
+      Organization("com.softwaremill.scalamacrodebug") -> Name("macros"),
+      Organization("com.github.ajozwik")               -> Name("macro")
+    )
+}
+
+object CompatibleWithScala3Lib {
+  def from(lib: Lib213): CompatibleWithScala3Lib =
+    CompatibleWithScala3Lib(lib.organization, lib.name, lib.revision, lib.crossVersion)
+}

--- a/migrate/src/main/scala/migrate/interfaces/MigrateImpl.scala
+++ b/migrate/src/main/scala/migrate/interfaces/MigrateImpl.scala
@@ -50,6 +50,15 @@ final class MigrateImpl() extends Migrate {
     ScalaMigrat.migrateScalacOptions(s)
   }
 
+  override def migrateLibs(libs: jutil.List[Lib]): jutil.Map[Lib, jutil.List[Lib]] = {
+    val initialLibs = libs.asScala.toList
+    val res         = ScalaMigrat.migrateLibs(initialLibs)
+    // to Java ^^
+    res.map { case (initial, compatible) =>
+      initial.asInstanceOf[Lib] -> compatible.map(_.asInstanceOf[Lib]).asJava
+    }.asJava
+  }
+
   override def prepareMigration(
     unmanagedSources: jutil.List[Path],
     targetRoot: Path,

--- a/migrate/src/main/scala/migrate/utils/CoursierHelper.scala
+++ b/migrate/src/main/scala/migrate/utils/CoursierHelper.scala
@@ -1,0 +1,62 @@
+package migrate.utils
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContextExecutor
+
+import coursier.Repositories
+import migrate.CompatibleWithScala3Lib
+import migrate.Lib213
+import migrate.LibToMigrate.CrossVersion
+import migrate.LibToMigrate.Revision
+
+object CoursierHelper {
+  implicit val ec: ExecutionContextExecutor = ExecutionContext.global
+  val scala3Full                            = "3.0.0-M3"
+  val scala3Binary                          = "3.0.0-M3"
+  val scala213Binary                        = "2.13"
+
+  def getCompatibleForScala3Binary(lib: Lib213): Seq[CompatibleWithScala3Lib] = {
+    val revisions = searchRevisionsFor(lib, scala3Binary)
+    val all = revisions.map { r =>
+      CompatibleWithScala3Lib(lib.organization, lib.name, r, CrossVersion.For2_13Use3("", ""))
+    }
+    getNewerRevision(lib, all)
+  }
+  def getCompatibleForScala3Full(lib: Lib213): Seq[CompatibleWithScala3Lib] = {
+    val revisions = searchRevisionsFor(lib, scala3Full)
+    val all = revisions.map { r =>
+      CompatibleWithScala3Lib(lib.organization, lib.name, r, CrossVersion.Full("", ""))
+    }
+    getNewerRevision(lib, all)
+  }
+  def getCompatibleForBinary213(lib: Lib213): Seq[CompatibleWithScala3Lib] = {
+    val revisions = searchRevisionsFor(lib, scala213Binary)
+    val all = revisions.map { r =>
+      CompatibleWithScala3Lib(lib.organization, lib.name, r, CrossVersion.For3Use2_13("", ""))
+    }
+    getNewerRevision(lib, all)
+  }
+
+  private[utils] def searchRevisionsFor(lib: Lib213, scalaV: String): Seq[Revision] = {
+    val libString = s"${lib.organization.value}:${lib.name.value}_$scalaV:"
+    val res = coursier.complete
+      .Complete()
+      .withRepositories(Seq(Repositories.central))
+      .withInput(libString)
+      .result()
+      .unsafeRun()(ec)
+      .results
+    val revisions = res.flatMap {
+      case (_, Right(revisions)) => revisions
+      case _                     => Nil
+    }
+    revisions.map(Revision(_))
+  }
+
+  private def getNewerRevision(
+    lib: Lib213,
+    compatibleLibs: Seq[CompatibleWithScala3Lib]
+  ): Seq[CompatibleWithScala3Lib] =
+    compatibleLibs.filter(l => l.revision >= lib.revision)
+
+}

--- a/migrate/src/main/scala/migrate/utils/CoursierHelper.scala
+++ b/migrate/src/main/scala/migrate/utils/CoursierHelper.scala
@@ -37,7 +37,7 @@ object CoursierHelper {
     getNewerRevision(lib, all)
   }
 
-  private[utils] def searchRevisionsFor(lib: Lib213, scalaV: String): Seq[Revision] = {
+  private def searchRevisionsFor(lib: Lib213, scalaV: String): Seq[Revision] = {
     val libString = s"${lib.organization.value}:${lib.name.value}_$scalaV:"
     val res = coursier.complete
       .Complete()
@@ -53,10 +53,14 @@ object CoursierHelper {
     revisions.map(Revision(_))
   }
 
+  // Rely on coursier order
   private def getNewerRevision(
     lib: Lib213,
     compatibleLibs: Seq[CompatibleWithScala3Lib]
-  ): Seq[CompatibleWithScala3Lib] =
-    compatibleLibs.filter(l => l.revision >= lib.revision)
+  ): Seq[CompatibleWithScala3Lib] = {
+    val possibleRevisions = compatibleLibs.map(_.revision).zipWithIndex.toMap
+    val index             = possibleRevisions.get(lib.revision)
+    index.map(compatibleLibs.drop).getOrElse(Nil)
+  }
 
 }

--- a/migrate/src/test/scala/migrate/MigrateLibsSuite.scala
+++ b/migrate/src/test/scala/migrate/MigrateLibsSuite.scala
@@ -1,0 +1,57 @@
+package migrate
+
+import migrate.LibToMigrate.CrossVersion
+import migrate.LibToMigrate.Revision
+import org.scalatest.funsuite.AnyFunSuiteLike
+import scalafix.testkit.DiffAssertions
+
+class MigrateLibsSuite extends AnyFunSuiteLike with DiffAssertions {
+  val binary: CrossVersion.Binary = CrossVersion.Binary("", "")
+
+  val zioTests: Lib213      = Lib213.from("dev.zio:zio-test:1.0.4", binary).get
+  val opentelemetry: Lib213 = Lib213.from("io.opentelemetry:opentelemetry-api:0.7.1", CrossVersion.Disabled).get
+  val collection: Lib213    = Lib213.from("org.scala-lang.modules:scala-collection-compat:2.4.0", binary).get
+  val kind: Lib213          = Lib213.from("org.typelevel:kind-projector:0.11.3", binary).get
+  val scalafix: Lib213      = Lib213.from("ch.epfl.scala:scalafix-core:0.9.24", binary).get
+  val macroLib: Lib213      = Lib213.from("com.softwaremill.scalamacrodebug:macros:0.4.1", binary).get
+
+  test("Not available lib") {
+    val migrated = ScalaMigrat.migrateLibs(Seq(kind))
+    assert(migrated(kind).isEmpty)
+  }
+  test("Java lib") {
+    val migrated = ScalaMigrat.migrateLibs(Seq(opentelemetry))
+    assert(migrated(opentelemetry).size == 1)
+    val res = migrated(opentelemetry).head
+    assert(isTheSame(opentelemetry, res))
+  }
+  test("Available in scala 3") {
+    val migrated = ScalaMigrat.migrateLibs(Seq(zioTests))
+    val res      = migrated(zioTests)
+    assert(res.nonEmpty)
+    println(s"res.map(_.crossVersion) = ${res.map(_.crossVersion)}")
+    assert(res.forall(_.crossVersion.isInstanceOf[CrossVersion.For2_13Use3]))
+  }
+  test("Don't show older version") {
+    val migrated = ScalaMigrat.migrateLibs(Seq(collection))
+    val res      = migrated(collection).map(_.revision)
+    val revision = Revision("2.3.2")
+    assert(!res.contains(revision))
+  }
+  test("Not available lib in scala 3 ") {
+    val migrateLib = ScalaMigrat.migrateLibs(Seq(scalafix))
+    val res        = migrateLib(scalafix)
+    assert(res.nonEmpty)
+    assert(res.forall(_.crossVersion.isInstanceOf[CrossVersion.For3Use2_13]))
+    assert(res.map(_.revision).contains(scalafix.revision))
+  }
+  // Warning: this test may change if the lib is ported to scala 3
+  test("Not migrated because macro lib") {
+    val migrateLib = ScalaMigrat.migrateLibs(Seq(macroLib))
+    val res        = migrateLib(macroLib)
+    assert(res.isEmpty)
+  }
+
+  private def isTheSame(lib: Lib213, migrated: CompatibleWithScala3Lib) =
+    lib.organization == migrated.organization && lib.name == migrated.name && lib.revision == migrated.revision && lib.crossVersion == migrated.crossVersion
+}

--- a/migrate/src/test/scala/migrate/utils/LibToMigrate.scala
+++ b/migrate/src/test/scala/migrate/utils/LibToMigrate.scala
@@ -1,0 +1,26 @@
+package migrate.utils
+
+import scala.util.Random
+
+import migrate.Lib213
+import migrate.LibToMigrate.CrossVersion
+import migrate.LibToMigrate.Revision
+import org.scalatest.funsuite.AnyFunSuiteLike
+import scalafix.testkit.DiffAssertions
+
+class LibToMigrate() extends AnyFunSuiteLike with DiffAssertions {
+  val binary: CrossVersion.Binary = CrossVersion.Binary("", "")
+  val scalafix: Lib213            = Lib213.from("ch.epfl.scala:scalafix-core:0.9.24", binary).get
+
+  test("revision ordering") {
+    val revisions213 = CoursierHelper.searchRevisionsFor(scalafix, "2.13")
+    val shuffled     = Random.shuffle(revisions213)
+    assert(revisions213 == shuffled.sorted)
+  }
+  //TODO FIX - Wrong revision
+  test("wrong revision ordering") {
+    Revision("1.0.0-RC21-2")
+    Revision("1.0.0")
+//   assert(Seq(revision1, revision2) ==  Seq(revision1, revision2).sorted)
+  }
+}

--- a/plugin/src/main/scala/interfaceImpl/LibImpl.scala
+++ b/plugin/src/main/scala/interfaceImpl/LibImpl.scala
@@ -1,0 +1,13 @@
+package interfaceImpl
+
+import migrate.interfaces.Lib
+import sbt.librarymanagement.ModuleID
+
+case class LibImpl(lib: ModuleID) extends Lib {
+  override def getOrganization: String = lib.organization
+  override def getName: String         = lib.name
+  override def getRevision: String     = lib.revision
+  override def getCrossVersion: String = lib.crossVersion.toString()
+
+  override def toString: String = s"${this.getOrganization}:${this.getName}:${this.getRevision}"
+}

--- a/plugin/src/main/scala/migrate/CommandStrings.scala
+++ b/plugin/src/main/scala/migrate/CommandStrings.scala
@@ -27,7 +27,18 @@ object CommandStrings {
   val migrateScalacOptionsDetailed =
     s"""|$migrateScalacOptionsCommand <projectId>
         |
-        | Print the migrated scalacOptions for Scala 3 so you can update you scalacOptions
+        |Print the migrated scalacOptions for Scala 3 so you can update you scalacOptions
+        | 
+        |
+        |""".stripMargin
+
+  val migrateLibs      = "migrate-libs"
+  val migrateLibsBrief = (migrateLibs, "Find and show the new versions of libs in order to migrate to Scala 3")
+  val migrateLibsDetailed =
+    s"""|$migrateLibs <projectId>
+        |
+        |Coursier is used to find, for each dependency, a Scala 3 version.
+        |If the lib is not published for Scala 3 yet, versions compatible with 2.13 are reported, in case the lib does not contain macros.
         | 
         |
         |""".stripMargin

--- a/plugin/src/main/scala/migrate/Messages.scala
+++ b/plugin/src/main/scala/migrate/Messages.scala
@@ -1,5 +1,7 @@
 package migrate
 
+import migrate.interfaces.Lib
+
 object Messages {
   def welcomeMigration: String        = "We are going to migrate your project to scala 3"
   def welcomePrepareMigration: String = "We are going to fix some syntax incompatibilities"
@@ -96,6 +98,38 @@ object Messages {
          |
          |
          |""".stripMargin
+
+  def migrateLibsStarting(projectId: String): String =
+    s"""|
+        |
+        |Starting to migrate libDependencies for $projectId
+        |""".stripMargin
+
+  def notMigratedLibs(libs: Seq[Lib]): String =
+    s"""|
+        |
+        |The following list of libs cannot be migrated.
+        |Please check the migration guide for more information. 
+        |${libs.map(_.toString).mkString("\n")}
+        |
+        |""".stripMargin
+
+  def migratedLib(libs: Map[Lib, Seq[Lib]]): String =
+    s"""|
+        |
+        |You can update your libs with the following versions: 
+        |
+        |${format(libs)}
+        |
+        |
+        |
+        |""".stripMargin
+
+  private def format(libs: Map[Lib, Seq[Lib]]): String =
+    libs.map(format).mkString("\n")
+
+  private def format(l: (Lib, Seq[Lib])): String =
+    s"""\"${l._1}\" -> ${l._2.mkString("\"", "\", ", "\"")}"""
 
   private def format(l: Seq[String]): String =
     l.mkString("Seq(\n\"", "\",\n\"", "\"\n)")


### PR DESCRIPTION
```
[info]
[info] Starting to migrate libDependencies for fetchJVM
[info]
[info]
[info] The following list of libs cannot be migrated.
[info] Please check the migration guide for more information.
[info] org.typelevel:kind-projector:0.11.3
[info]
[info]
[info]
[info]
[info]
[info] You can update your libs with the following versions:
[info]
[info] "org.scala-lang:scala-library:2.13.4" -> "org.scala-lang:scala-library:2.13.4"
[info] "org.typelevel:cats-effect:2.3.1" -> "org.typelevel:cats-effect:2.3.1", org.typelevel:cats-effect:3.0.0-M5", org.typelevel:cats-effect:3.0.0-RC1", org.typelevel:cats-effect:3.0-27-4e31907", org.typelevel:cats-effect:3.0-42-83f5c56", org.typelevel:cats-effect:3.0-65-7c98c86", org.typelevel:cats-effect:3.0-193-3231190"
[info] "org.scalatest:scalatest:3.2.3" -> "org.scalatest:scalatest:3.2.3", org.scalatest:scalatest:3.2.4-M1"
```

I still need to deal with Module that are compiler plugins. 