### PR TITLE
Fix high allocation rate when computing patches for both rules

### DIFF
--- a/migrate/src/main/scala/migrate/utils/ScalafixService.scala
+++ b/migrate/src/main/scala/migrate/utils/ScalafixService.scala
@@ -78,7 +78,7 @@ object ScalafixService {
     "fix.scala213.ExplicitNonNullaryApply",
     "fix.scala213.Any2StringAdd"
   )
-  val addExplicitResultTypesAndImplicits: Seq[String] = Seq("InferTypes", "ExplicitImplicits")
+  val addExplicitResultTypesAndImplicits: Seq[String] = Seq("MigrationRule")
 
   def from(compilerOptions: Seq[String], classpath: Classpath, targetRootSemantic: AbsolutePath): Try[ScalafixService] =
     for {

--- a/scalafix/input/src/main/scala/implicits/Mix.scala
+++ b/scalafix/input/src/main/scala/implicits/Mix.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package implicits
 

--- a/scalafix/input/src/main/scala/incompat/Cats1.scala
+++ b/scalafix/input/src/main/scala/incompat/Cats1.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package cats
 

--- a/scalafix/input/src/main/scala/incompat/Cats2.scala
+++ b/scalafix/input/src/main/scala/incompat/Cats2.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package cats
 

--- a/scalafix/input/src/main/scala/incompat/Cats5.scala
+++ b/scalafix/input/src/main/scala/incompat/Cats5.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package cats
 package instances

--- a/scalafix/input/src/main/scala/incompat/Cats6.scala
+++ b/scalafix/input/src/main/scala/incompat/Cats6.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package cats.instances
 

--- a/scalafix/input/src/main/scala/incompat/ScalafixIncompat1.scala
+++ b/scalafix/input/src/main/scala/incompat/ScalafixIncompat1.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package incompat
 

--- a/scalafix/input/src/main/scala/incompat/ScalafixIncompat11.scala
+++ b/scalafix/input/src/main/scala/incompat/ScalafixIncompat11.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package incompat
 

--- a/scalafix/input/src/main/scala/incompat/ScalafixIncompat12.scala
+++ b/scalafix/input/src/main/scala/incompat/ScalafixIncompat12.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package incompat
 

--- a/scalafix/input/src/main/scala/incompat/ScalafixIncompat13.scala
+++ b/scalafix/input/src/main/scala/incompat/ScalafixIncompat13.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package incompat
 

--- a/scalafix/input/src/main/scala/incompat/ScalafixIncompat2.scala
+++ b/scalafix/input/src/main/scala/incompat/ScalafixIncompat2.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package incompat
 

--- a/scalafix/input/src/main/scala/incompat/ScalafixIncompat3.scala
+++ b/scalafix/input/src/main/scala/incompat/ScalafixIncompat3.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package incompat
 

--- a/scalafix/input/src/main/scala/incompat/ScalafixIncompat4.scala
+++ b/scalafix/input/src/main/scala/incompat/ScalafixIncompat4.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package incompat
 

--- a/scalafix/input/src/main/scala/incompat/ScalafixIncompat5.scala
+++ b/scalafix/input/src/main/scala/incompat/ScalafixIncompat5.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package incompat
 

--- a/scalafix/input/src/main/scala/incompat/ScalafixIncompat6.scala
+++ b/scalafix/input/src/main/scala/incompat/ScalafixIncompat6.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package incompat
 

--- a/scalafix/input/src/main/scala/incompat/ScalafixIncompat7.scala
+++ b/scalafix/input/src/main/scala/incompat/ScalafixIncompat7.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package incompat
 

--- a/scalafix/input/src/main/scala/incompat/ScalafixIncompat8.scala
+++ b/scalafix/input/src/main/scala/incompat/ScalafixIncompat8.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package incompat
 

--- a/scalafix/input/src/main/scala/incompat/ScalafixIncompat9.scala
+++ b/scalafix/input/src/main/scala/incompat/ScalafixIncompat9.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package incompat
 

--- a/scalafix/input/src/main/scala/migrate/AnyRefWith.scala
+++ b/scalafix/input/src/main/scala/migrate/AnyRefWith.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 
 package migrate

--- a/scalafix/input/src/main/scala/migrate/Basic.scala
+++ b/scalafix/input/src/main/scala/migrate/Basic.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/EnumerationValue.scala
+++ b/scalafix/input/src/main/scala/migrate/EnumerationValue.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/ExplicitResultTypesArrayBuffer.scala
+++ b/scalafix/input/src/main/scala/migrate/ExplicitResultTypesArrayBuffer.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/ExplicitResultTypesBase.scala
+++ b/scalafix/input/src/main/scala/migrate/ExplicitResultTypesBase.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/ExplicitResultTypesDiverse.scala
+++ b/scalafix/input/src/main/scala/migrate/ExplicitResultTypesDiverse.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/ExplicitResultTypesImports.scala
+++ b/scalafix/input/src/main/scala/migrate/ExplicitResultTypesImports.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/ExplicitResultTypesNil.scala
+++ b/scalafix/input/src/main/scala/migrate/ExplicitResultTypesNil.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/ExplicitResultTypesOutline.scala
+++ b/scalafix/input/src/main/scala/migrate/ExplicitResultTypesOutline.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/ExplicitResultTypesPartialFunction.scala
+++ b/scalafix/input/src/main/scala/migrate/ExplicitResultTypesPartialFunction.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/ExplicitResultTypesPathDependent.scala
+++ b/scalafix/input/src/main/scala/migrate/ExplicitResultTypesPathDependent.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/ExplicitResultTypesPrefix.scala
+++ b/scalafix/input/src/main/scala/migrate/ExplicitResultTypesPrefix.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/ExplicitResultTypesRefinement.scala
+++ b/scalafix/input/src/main/scala/migrate/ExplicitResultTypesRefinement.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/ExplicitResultTypesShort.scala
+++ b/scalafix/input/src/main/scala/migrate/ExplicitResultTypesShort.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/ExplicitResultTypesSingleton.scala
+++ b/scalafix/input/src/main/scala/migrate/ExplicitResultTypesSingleton.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/ExplicitResultTypesSupermethod.scala
+++ b/scalafix/input/src/main/scala/migrate/ExplicitResultTypesSupermethod.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/ExplicitResultTypesTrait.scala
+++ b/scalafix/input/src/main/scala/migrate/ExplicitResultTypesTrait.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/FinalVal.scala
+++ b/scalafix/input/src/main/scala/migrate/FinalVal.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/ImmutableMap.scala
+++ b/scalafix/input/src/main/scala/migrate/ImmutableMap.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/ImmutableSeq.scala
+++ b/scalafix/input/src/main/scala/migrate/ImmutableSeq.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/LowerBound.scala
+++ b/scalafix/input/src/main/scala/migrate/LowerBound.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/ManagedFile.scala
+++ b/scalafix/input/src/main/scala/migrate/ManagedFile.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/NameConflict.scala
+++ b/scalafix/input/src/main/scala/migrate/NameConflict.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/NotSupported_fails.scala
+++ b/scalafix/input/src/main/scala/migrate/NotSupported_fails.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/RefinementConfig.scala
+++ b/scalafix/input/src/main/scala/migrate/RefinementConfig.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/Rename.scala
+++ b/scalafix/input/src/main/scala/migrate/Rename.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/RscCompat.scala
+++ b/scalafix/input/src/main/scala/migrate/RscCompat.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/ScalaPackage.scala
+++ b/scalafix/input/src/main/scala/migrate/ScalaPackage.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/SeenFromTypeParams.scala
+++ b/scalafix/input/src/main/scala/migrate/SeenFromTypeParams.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/Simple.scala
+++ b/scalafix/input/src/main/scala/migrate/Simple.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/ThisTypeRef.scala
+++ b/scalafix/input/src/main/scala/migrate/ThisTypeRef.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/WidenSingleType.scala
+++ b/scalafix/input/src/main/scala/migrate/WidenSingleType.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/migrate/testpkg/package.scala
+++ b/scalafix/input/src/main/scala/migrate/testpkg/package.scala
@@ -1,5 +1,5 @@
 /*
-rule = [InferTypes, ExplicitImplicits]
+rule = [MigrationRule]
 */
 package migrate
 

--- a/scalafix/input/src/main/scala/types/CyclicSymbols.scala
+++ b/scalafix/input/src/main/scala/types/CyclicSymbols.scala
@@ -1,5 +1,5 @@
 /*
-rules = [InferTypes, ExplicitImplicits]
+rules = [MigrationRule]
 */
 package types
 

--- a/scalafix/input/src/main/scala/types/CyclicTypes.scala
+++ b/scalafix/input/src/main/scala/types/CyclicTypes.scala
@@ -1,5 +1,5 @@
 /*
-rules = [InferTypes, ExplicitImplicits]
+rules = [MigrationRule]
 */
 package types
 

--- a/scalafix/input/src/main/scala/types/ImplicitConversion.scala
+++ b/scalafix/input/src/main/scala/types/ImplicitConversion.scala
@@ -1,5 +1,5 @@
 /*
-rules = [InferTypes, ExplicitImplicits]
+rules = [MigrationRule]
 */
 package cats
 package data

--- a/scalafix/input/src/main/scala/types/PolyTypes.scala
+++ b/scalafix/input/src/main/scala/types/PolyTypes.scala
@@ -1,5 +1,5 @@
 /*
-rules = [InferTypes, ExplicitImplicits]
+rules = [MigrationRule]
 */
 package cats
 package data

--- a/scalafix/input/src/main/scala/types/StructuralRefinement.scala
+++ b/scalafix/input/src/main/scala/types/StructuralRefinement.scala
@@ -1,5 +1,5 @@
 /*
-rules = [InferTypes, ExplicitImplicits]
+rules = [MigrationRule]
 */
 
 package types

--- a/scalafix/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/scalafix/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,2 +1,1 @@
-migrate.InferTypes
-migrate.ExplicitImplicitsRule
+migrate.MigrateRule

--- a/scalafix/rules/src/main/scala/migrate/MigrateRule.scala
+++ b/scalafix/rules/src/main/scala/migrate/MigrateRule.scala
@@ -1,0 +1,49 @@
+package migrate
+
+import scala.tools.nsc.interactive.Global
+import scala.tools.nsc.reporters.StoreReporter
+import scala.util.Failure
+import scala.util.Success
+import scala.util.control.NonFatal
+
+import metaconfig.Configured
+import scalafix.patch.Patch
+import scalafix.v1.Configuration
+import scalafix.v1.Rule
+import scalafix.v1.SemanticDocument
+import scalafix.v1.SemanticRule
+import utils.CompilerService
+
+class MigrateRule(g: Global) extends SemanticRule("MigrationRule") {
+  override def description: String = "infer types"
+
+  def this() = this(null)
+
+  override def withConfiguration(config: Configuration): Configured[Rule] =
+    if (config.scalacClasspath.isEmpty) {
+      Configured.error(s"config.scalacClasspath should not be empty")
+    } else {
+      val global = CompilerService.newGlobal(config.scalacClasspath, config.scalacOptions)
+      global match {
+        case Success(settings) =>
+          Configured.ok(new MigrateRule(new Global(settings, new StoreReporter, "scala3-migrate")))
+        case Failure(exception) => Configured.error(exception.getMessage)
+      }
+    }
+
+  override def afterComplete(): Unit =
+    try {
+      g.askShutdown()
+      g.close()
+    } catch {
+      case NonFatal(_) =>
+    }
+
+  override def fix(implicit doc: SemanticDocument): Patch = {
+    lazy implicit val compilerService: CompilerService[g.type] = new CompilerService(g, doc)
+
+    val inferType        = new InferTypes[g.type](g)
+    val explicitImplicit = new ExplicitImplicitsRule[g.type](g)
+    inferType.fix + explicitImplicit.fix
+  }
+}

--- a/scalafix/rules/src/main/scala/utils/GlobalProxyService.scala
+++ b/scalafix/rules/src/main/scala/utils/GlobalProxyService.scala
@@ -1,14 +1,15 @@
-package scala.meta.internal.proxy
+package scala.tools.nsc.interactive
 
 import scala.reflect.internal.util.Position
-import scala.tools.nsc.interactive.Global
+import scala.reflect.internal.util.SourceFile
 
-object GlobalProxyService {
-  def typedTreeAt(g: Global, pos: Position): g.Tree = {
-    // NOTE(olafur) clearing `unitOfFile` fixes a bug where `typedTreeAt` would
-    // produce symbols with erroneous `.info` signatures.
-    g.unitOfFile.clear()
-    g.typedTreeAt(pos)
-  }
+class GlobalProxyService[G <: Global](g: G, sourceFile: SourceFile) {
+  // load only once the source and type it
+  // It's expensive since it load caches and create a RichCompilationUnit
+  private val _ = g.reloadSource(sourceFile)
+  private val _ = g.typedTree(sourceFile, true)
+
+  def typedTreeAt(pos: Position): G#Tree =
+    g.locateTree(pos)
 
 }


### PR DESCRIPTION
- Use the same global by merging the 2 rules
- Type the entire tree only once and then just locate the smallest tree