### PR TITLE
Workaround to fix the command migrate on crossPlatform projects

### DIFF
--- a/plugin/src/main/scala/migrate/ScalaMigratePlugin.scala
+++ b/plugin/src/main/scala/migrate/ScalaMigratePlugin.scala
@@ -117,7 +117,7 @@ object ScalaMigratePlugin extends AutoPlugin {
         s"${projectId} / isScala213",
         s"$projectId / compile",
         s"$projectId / storeScala2Inputs",
-        s"""set $projectId / scalaVersion := "${scala3Version}"""",
+        s"""set LocalProject("$projectId") / scalaVersion := "${scala3Version}"""",
         s"$projectId / storeScala3Inputs",
         s"$projectId / internalMigrate",
         PopOnFailure,


### PR DESCRIPTION
For example
lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
coreJVM/compile => works
set coreJVM/scalaVersion := "3.0.0" => doesn't work
set core.jvm/scalaVersion := "3.0.0" => works
core.jvm/compile => doesn't work