### PR TITLE
empty.maxBy in Compile / internalMigrateLibs when there are no libraries.

### DIFF
--- a/plugin/src/main/scala/migrate/Messages.scala
+++ b/plugin/src/main/scala/migrate/Messages.scala
@@ -181,7 +181,7 @@ object Messages {
   }
 
   def computeLongestValue(values: Seq[String]): Int =
-    values.maxBy(_.length).length
+    if (values.isEmpty) 0 else values.maxBy(_.length).length
 
   def formatValueWithSpace(value: String, longestValue: Int): String = {
     val numberOfSpaces = " " * (longestValue - value.length)


### PR DESCRIPTION
As called from line 268 of ScalaMigratePlugin.scala this method results in: "[error] (Compile / internalMigrateLibs) java.lang.UnsupportedOperationException: empty.maxBy" if there are no library dependencies at all in a project. I do *not* know that zero is definitely the appropriate result if there are no values. Please check that, thank you.