### PR TITLE
Corrected text of error message ("you" to "Your") [Take 2]

### DIFF
--- a/plugin/src/main/scala/migrate/Messages.scala
+++ b/plugin/src/main/scala/migrate/Messages.scala
@@ -13,8 +13,8 @@ object Messages {
        |
        |Error:
        |
-       |you project must be in 2.13 and not in $scalaVersion
-       |please change the scalaVersion following this command
+       |Your project must be in 2.13 and not in $scalaVersion
+       |Please change the scalaVersion following this command
        |set LocalProject("$projectId") / scalaVersion := "2.13.5"
        |
        |


### PR DESCRIPTION
I hope this PR is correct now. My branch claims *"This branch is 4 commits ahead of scalacenter:main."*
As before:
*Corrected text of error message:
"**you** project must be" to
"**your** project must be"
Also capitalised first two lines of error message.*