### PR TITLE
Fix fallback

### DIFF
--- a/plugin/src/main/scala/migrate/CommandStrings.scala
+++ b/plugin/src/main/scala/migrate/CommandStrings.scala
@@ -1,7 +1,6 @@
 package migrate
 
 object CommandStrings {
-
   val migrateSyntaxCommand = "migrate-syntax"
   val migrateSyntaxBrief =
     (s"$migrateSyntaxCommand <projectId>", "Fix syntax incompatibilities for scala 3 for a specific projectId")
@@ -47,4 +46,6 @@ object CommandStrings {
         | 
         |
         |""".stripMargin
+
+  val migrateFallback = "migrate-fallback"
 }

--- a/plugin/src/sbt-test/sbt-scala3-migrate/unresolved-dependencies/test
+++ b/plugin/src/sbt-test/sbt-scala3-migrate/unresolved-dependencies/test
@@ -1,6 +1,6 @@
-# the library dependencies of project foo have not been updated for Scala 3
-# it should fails
--> migrate unresolved-dependencies
+# The library dependencies of project foo have not been updated for Scala 3
+# Although migration fails, the command does not because of the fallback. It could be improved.
+> migrate unresolved-dependencies
 
 # check fallback to Scala 2.13
 > unresolved-dependencies / checkFallback


### PR DESCRIPTION
I cannot find an automatic fallback mechanism in sbt to go back to a previous state.

Instead I added a `migrateFallback` command whose purpose is to set the `scalaVersion` back to its initial value (Scala 2.13) in case of failure.

```
sbt:main> show main / scalaVersion
[info] 2.13.5
sbt:main> migrate main
[info] Defining scalaVersion
...
[info] Updating
...
[error] (update) sbt.librarymanagement.ResolveException: Error downloading org.typelevel:cats-core_3.0.0-RC2:2.4.2
...
[info] Defining scalaVersion
...
sbt:main> show main / scalaVersion
[info] 2.13.5
sbt:main>
```