### PR TITLE
Keep binary crossVersion when the revision of a lib is available for …

### DIFF
--- a/migrate/src/main/scala/migrate/internal/ScalaVersion.scala
+++ b/migrate/src/main/scala/migrate/internal/ScalaVersion.scala
@@ -7,8 +7,11 @@ import scala.util.Try
 import migrate.internal.ScalaVersion._
 sealed trait ScalaVersion {
   val major: MajorVersion
-  val minor: Option[Int]
+  val minor: Int
   val patch: Option[Int]
+  val binary: String =
+    if (isScala3) major.value.toString
+    else s"${major.value}.${minor}"
 
   def isScala2: Boolean = major == scala2
   def isScala3: Boolean = major == scala3
@@ -24,13 +27,11 @@ object ScalaVersion {
   val scala2: MajorVersion = Major.Scala2
   val scala3: MajorVersion = Major.Scala3
 
-  case class Minor(major: MajorVersion, minorVersion: Int) extends ScalaVersion {
-    override val minor: Some[Int] = Some(minorVersion)
-    override val patch            = None
+  case class Minor(major: MajorVersion, minor: Int) extends ScalaVersion {
+    override val patch = None
 
   }
-  case class Patch(major: MajorVersion, minorVersion: Int, patchVersion: Int) extends ScalaVersion {
-    override val minor: Some[Int] = Some(minorVersion)
+  case class Patch(major: MajorVersion, minor: Int, patchVersion: Int) extends ScalaVersion {
     override val patch: Some[Int] = Some(patchVersion)
   }
 

--- a/migrate/src/test/scala/migrate/MigrateLibsSuite.scala
+++ b/migrate/src/test/scala/migrate/MigrateLibsSuite.scala
@@ -39,7 +39,6 @@ class MigrateLibsSuite extends AnyFunSuiteLike with DiffAssertions {
     assert(res.getReasonWhy == MigratedLibImp.Reason.JavaLibrary.why)
     assert(isTheSame(opentelemetry, res))
   }
-
   test("java lib2") {
     val migrated = Scala3Migrate.migrateLibs(Seq(javaLib2)).allLibs
     val res      = migrated(javaLib2)
@@ -50,7 +49,13 @@ class MigrateLibsSuite extends AnyFunSuiteLike with DiffAssertions {
     val migrated = Scala3Migrate.migrateLibs(Seq(cats)).allLibs
     val res      = migrated(cats)
     assert(res.isCompatibleWithScala3)
-    assert(res.asInstanceOf[CompatibleWithScala3.Lib].crossVersion.isInstanceOf[CrossVersion.For2_13Use3])
+    assert(res.asInstanceOf[CompatibleWithScala3.Lib].crossVersion.isInstanceOf[CrossVersion.Binary])
+  }
+  test("available in scala 3 but with crossVersion.Disabled") {
+    val migrated = Scala3Migrate.migrateLibs(Seq(cats213)).allLibs
+    val res      = migrated(cats213)
+    assert(res.isCompatibleWithScala3)
+    assert(res.asInstanceOf[CompatibleWithScala3.Lib].crossVersion.isInstanceOf[CrossVersion.Binary])
   }
   test("Don't show older version") {
     val migrated = Scala3Migrate.migrateLibs(Seq(collection)).allLibs

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.2
+sbt.version=1.5.3


### PR DESCRIPTION
…both Scala 3 and 2