### PR TITLE
Improve messages for migrate-libs

### DIFF
--- a/migrate/src/main/scala/migrate/interfaces/MigratedLibImp.scala
+++ b/migrate/src/main/scala/migrate/interfaces/MigratedLibImp.scala
@@ -1,6 +1,8 @@
 package migrate.interfaces
 
+import migrate.interfaces.InitialLibImp.Revision
 import migrate.interfaces.MigratedLibImp._
+import migrate.internal.ScalaVersion
 
 trait MigratedLibImp extends MigratedLib {
   def reason: Reason
@@ -14,15 +16,23 @@ object MigratedLibImp {
 
   object Reason {
     case object ScalacOptionEquivalent
-        extends Reason("This compiler plugin has a scalacOption equivalent. Add it to your scalacOptions")
-    case object MacroLibrary            extends Reason("Contains Macros and is not yet published for Scala 3")
-    case object FullVersionNotAvailable extends Reason("Requires a full version and is not yet for scala 3 ")
+        extends Reason("This compiler plugin has a scalacOption equivalent. Add it to your scalacOptions.")
+    case object MacroLibrary extends Reason("Contains Macros and is not yet published for Scala 3.")
+    case class FullVersionNotAvailable(scalaVersion: ScalaVersion)
+        extends Reason(s"This dependency hasn't been published for ${scalaVersion.value}.")
     case object CompilerPlugin
-        extends Reason("Scala 2 compiler plugins are not supported in scala 3. You need to find an alternative")
-    case object Scala3LibAvailable extends Reason("This dependency is published for Scala 3. ")
-    case object JavaLibrary        extends Reason("This dependency is a Java library. It can be kept as it is. ")
-    case object IsAlreadyValid     extends Reason("")
-    case object For3Use2_13
-        extends Reason("This dependency is not yet published for scala 3 but the 2.13 version can be used")
+        extends Reason("Scala 2 compiler plugins are not supported in scala 3. You need to find an alternative.")
+    case class Scala3LibAvailable(otherRevisions: Seq[Revision])
+        extends Reason(
+          if (otherRevisions.nonEmpty) s"Other versions are avaialble for Scala 3: ${printRevisions(otherRevisions)}"
+          else ""
+        )
+    case object JavaLibrary    extends Reason("Java libraries are compatible.")
+    case object IsAlreadyValid extends Reason("")
+    case object For3Use2_13    extends Reason("It's only safe to use the 2.13 version if it's inside an application.")
+
+    private def printRevisions(r: Seq[Revision]): String =
+      if (r.size >= 3) s""""${r.head.value}", ..., "${r.last.value}""""
+      else r.map(_.value).mkString("\"", "\", \"", "\"")
   }
 }

--- a/migrate/src/main/scala/migrate/interfaces/MigratedLibsImpl.scala
+++ b/migrate/src/main/scala/migrate/interfaces/MigratedLibsImpl.scala
@@ -29,9 +29,9 @@ case class MigratedLibsImpl(
 
   private def initialLibSameThanCompatible(initialLib: InitialLib, compatible: CompatibleWithScala3): Boolean =
     compatible match {
-      case keptInitialLib: CompatibleWithScala3.Lib // maybe need to be fixed
-          if initialLib.crossVersion == keptInitialLib.crossVersion =>
-        true
+      case keptInitialLib: CompatibleWithScala3.Lib =>
+        initialLib.crossVersion == keptInitialLib.crossVersion &&
+          initialLib.revision == keptInitialLib.revision
       case _ => false
     }
 

--- a/migrate/src/main/scala/migrate/internal/InitialLib.scala
+++ b/migrate/src/main/scala/migrate/internal/InitialLib.scala
@@ -75,7 +75,7 @@ case class InitialLib(
         case Some(value) => CompatibleWithScala3.ScalacOption(value)
         case None        => this.toUncompatible(Reason.CompilerPlugin)
       }
-    } else this.toCompatibleLib(CrossVersion.Full("", ""), Reason.Scala3LibAvailable, revisions)
+    } else this.toCompatibleLib(CrossVersion.Full("", ""), Reason.Scala3LibAvailable(revisions.tail), revisions)
   }
 
   private def getCompatibleWhenBinaryCrossVersion(lib: InitialLib): MigratedLibImp = {
@@ -93,7 +93,7 @@ case class InitialLib(
             compatibleRevisionsForScala3,
             CrossVersion.Binary("", ""),
             lib.configurations,
-            Reason.Scala3LibAvailable
+            Reason.Scala3LibAvailable(compatibleRevisionsForScala3.tail)
           )
         else
           CompatibleWithScala3.Lib(
@@ -102,7 +102,7 @@ case class InitialLib(
             compatibleRevisionsForScala3,
             CrossVersion.For2_13Use3("", ""),
             lib.configurations,
-            Reason.Scala3LibAvailable
+            Reason.Scala3LibAvailable(compatibleRevisionsForScala3.tail)
           )
 
     }
@@ -110,7 +110,7 @@ case class InitialLib(
 
   private def getCompatibleWhenFullCrossVersion(lib: InitialLib): MigratedLibImp =
     CoursierHelper.getCompatibleForScala3Full(lib) match {
-      case Nil => lib.toUncompatible(Reason.FullVersionNotAvailable)
+      case Nil => lib.toUncompatible(Reason.FullVersionNotAvailable(CoursierHelper.scala3Full))
       case revisions =>
         CompatibleWithScala3.Lib(
           lib.organization,
@@ -118,7 +118,7 @@ case class InitialLib(
           revisions,
           CrossVersion.For2_13Use3("", ""),
           lib.configurations,
-          Reason.Scala3LibAvailable
+          Reason.Scala3LibAvailable(revisions.tail)
         )
     }
 }

--- a/migrate/src/main/scala/migrate/internal/MigratedLib.scala
+++ b/migrate/src/main/scala/migrate/internal/MigratedLib.scala
@@ -31,9 +31,13 @@ object MigratedLib {
         val orgQuoted      = withQuote(organization.value)
         val revisionQuoted = withQuote(revision.value)
         crossVersion match {
-          case CrossVersion.Disabled => s"$orgQuoted % ${withQuote(name.value)} % $revisionQuoted$configuration"
+          case CrossVersion.Disabled       => s"$orgQuoted % ${withQuote(name.value)} % $revisionQuoted$configuration"
+          case CrossVersion.Binary("", "") => s"$orgQuoted %% ${withQuote(name.value)} % $revisionQuoted$configuration"
+          case CrossVersion.Full("", "")   => s"$orgQuoted %% ${withQuote(name.value)} % $revisionQuoted$configuration"
           case CrossVersion.For3Use2_13(_, _) =>
             s"$orgQuoted %% ${withQuote(name.value)} % $revisionQuoted$configuration cross CrossVersion.for3Use2_13"
+          case CrossVersion.For2_13Use3(_, _) =>
+            s"$orgQuoted %% ${withQuote(name.value)} % $revisionQuoted$configuration cross CrossVersion.for2_13Use3"
           case _ => s"$orgQuoted % ${withQuote(name.value)} % $revisionQuoted$configuration"
         }
       }

--- a/migrate/src/main/scala/migrate/utils/CoursierHelper.scala
+++ b/migrate/src/main/scala/migrate/utils/CoursierHelper.scala
@@ -11,7 +11,7 @@ import migrate.internal.ScalaVersion
 
 object CoursierHelper {
   implicit val ec: ExecutionContextExecutor = ExecutionContext.global
-  private val scala3Full: ScalaVersion      = ScalaVersion.from(BuildInfo.scala3Version).get
+  val scala3Full: ScalaVersion              = ScalaVersion.from(BuildInfo.scala3Version).get
 
   def getCompatibleForScala3Binary(lib: InitialLib): Seq[Revision] = {
     val revisions = searchRevisionsFor(lib, scala3Full.binary)

--- a/migrate/src/test/scala/migrate/MigrateLibsSuite.scala
+++ b/migrate/src/test/scala/migrate/MigrateLibsSuite.scala
@@ -2,7 +2,7 @@ package migrate
 
 import migrate.interfaces.InitialLibImp._
 import migrate.interfaces.MigratedLib
-import migrate.interfaces.MigratedLibImp
+import migrate.interfaces.MigratedLibImp._
 import migrate.internal.InitialLib
 import migrate.internal.MigratedLib._
 import org.scalatest.funsuite.AnyFunSuiteLike
@@ -36,7 +36,7 @@ class MigrateLibsSuite extends AnyFunSuiteLike with DiffAssertions {
     val migrated = Scala3Migrate.migrateLibs(Seq(opentelemetry)).allLibs
     val res      = migrated(opentelemetry)
     assert(res.isCompatibleWithScala3)
-    assert(res.getReasonWhy == MigratedLibImp.Reason.JavaLibrary.why)
+    assert(res.getReasonWhy == Reason.JavaLibrary.why)
     assert(isTheSame(opentelemetry, res))
   }
   test("java lib2") {
@@ -81,6 +81,15 @@ class MigrateLibsSuite extends AnyFunSuiteLike with DiffAssertions {
     val scalajs     = InitialLib.from("org.scala-js:scalajs-compiler:1.5.0", CrossVersion.Disabled, None).get
     val migratedLib = Scala3Migrate.migrateLibs(Seq(scalaLib, scalajs)).allLibs
     assert(migratedLib.isEmpty)
+  }
+  test("message for Scala3LibAvailable") {
+    val revisions = Seq(Revision("1"), Revision("2"), Revision("3"), Revision("4"))
+    val message   = Reason.Scala3LibAvailable(revisions).why
+    assert(message == "Other versions are avaialble for Scala 3: \"1\", ..., \"4\"")
+    val revisions2 = Seq(Revision("1"), Revision("2"))
+    val message2   = Reason.Scala3LibAvailable(revisions2).why
+    println(s"message2 = ${message2}")
+    assert(message2 == "Other versions are avaialble for Scala 3: \"1\", \"2\"")
   }
 
   private def isTheSame(lib: InitialLib, migrated: MigratedLib) =


### PR DESCRIPTION
fixes #181 : we add a warning message to say it's only safe in application to use the 213 version in scala 3 
fixes #179: we only show the first one, but we add more versions in the comment after