### PR TITLE
Remove rules from migrate-syntax that are provided by scala 3 compile…

### DIFF
--- a/input/src/main/scala/migrateSyntax/Any2String.scala
+++ b/input/src/main/scala/migrateSyntax/Any2String.scala
@@ -1,0 +1,5 @@
+package migrateSyntax
+
+object Any2String {
+  val str = new AnyRef + "foo"
+}

--- a/input/src/main/scala/migrateSyntax/AutoApplication.scala
+++ b/input/src/main/scala/migrateSyntax/AutoApplication.scala
@@ -1,8 +1,0 @@
-package migrateSyntax
-
-object AutoApplication {
-  trait Chunk {
-    def bytes(): Seq[Byte]
-    def toSeq: Seq[Byte] = bytes
-  }
-}

--- a/input/src/main/scala/migrateSyntax/LambdaParam.scala
+++ b/input/src/main/scala/migrateSyntax/LambdaParam.scala
@@ -1,5 +1,0 @@
-package migrateSyntax
-
-object LambdaParam {
-  val f = { x: Int => x * x }
-}

--- a/input/src/main/scala/migrateSyntax/ValueEtaExpansion.scala
+++ b/input/src/main/scala/migrateSyntax/ValueEtaExpansion.scala
@@ -1,6 +1,0 @@
-package migrateSyntax
-
-object ValueEtaExpansion {
-  val x = 1
-  val f: () => Int = x _
-}

--- a/migrate/src/main/scala/migrate/utils/ScalafixService.scala
+++ b/migrate/src/main/scala/migrate/utils/ScalafixService.scala
@@ -70,13 +70,7 @@ object ScalafixService {
   private lazy val internalRules = getClassPathforMigrateRules()
   private lazy val externalRules = getClassPathforRewriteRules()
 
-  val fixSyntaxRules: Seq[String] = Seq(
-    "ProcedureSyntax",
-    "fix.scala213.ExplicitNullaryEtaExpansion",
-    "fix.scala213.ParensAroundLambda",
-    "fix.scala213.ExplicitNonNullaryApply",
-    "fix.scala213.Any2StringAdd"
-  )
+  val fixSyntaxRules: Seq[String]                     = Seq("ProcedureSyntax", "fix.scala213.Any2StringAdd", "ExplicitResultTypes")
   val addExplicitResultTypesAndImplicits: Seq[String] = Seq("MigrationRule")
 
   def from(compilerOptions: Seq[String], classpath: Classpath, targetRootSemantic: AbsolutePath): Try[ScalafixService] =

--- a/migrate/src/test/scala/migrate/MigrateLibsSuite.scala
+++ b/migrate/src/test/scala/migrate/MigrateLibsSuite.scala
@@ -60,7 +60,6 @@ class MigrateLibsSuite extends AnyFunSuiteLike {
     val migrated = Scala3Migrate.migrateLibs(Seq(cats213)).allLibs
     val res      = migrated(cats213)
     assert(res.isCompatibleWithScala3)
-    println(s"res = ${res}")
     assert(res.asInstanceOf[CompatibleWithScala3.Lib].crossVersion.isInstanceOf[CrossVersion.Binary])
   }
   test("Don't show older version") {
@@ -94,7 +93,6 @@ class MigrateLibsSuite extends AnyFunSuiteLike {
     assert(message == "Other versions are avaialble for Scala 3: \"1\", ..., \"4\"")
     val revisions2 = Seq(Revision("1"), Revision("2"))
     val message2   = Reason.Scala3LibAvailable(revisions2).why
-    println(s"message2 = ${message2}")
     assert(message2 == "Other versions are avaialble for Scala 3: \"1\", \"2\"")
   }
 

--- a/output/src/main/scala/migrateSyntax/Any2String.scala
+++ b/output/src/main/scala/migrateSyntax/Any2String.scala
@@ -1,0 +1,5 @@
+package migrateSyntax
+
+object Any2String {
+  val str: String = String.valueOf(new AnyRef) + "foo"
+}

--- a/output/src/main/scala/migrateSyntax/AutoApplication.scala
+++ b/output/src/main/scala/migrateSyntax/AutoApplication.scala
@@ -1,8 +1,0 @@
-package migrateSyntax
-
-object AutoApplication {
-  trait Chunk {
-    def bytes(): Seq[Byte]
-    def toSeq: Seq[Byte] = bytes()
-  }
-}

--- a/output/src/main/scala/migrateSyntax/LambdaParam.scala
+++ b/output/src/main/scala/migrateSyntax/LambdaParam.scala
@@ -1,5 +1,0 @@
-package migrateSyntax
-
-object LambdaParam {
-  val f = { (x: Int) => x * x }
-}

--- a/output/src/main/scala/migrateSyntax/ValueEtaExpansion.scala
+++ b/output/src/main/scala/migrateSyntax/ValueEtaExpansion.scala
@@ -1,6 +1,0 @@
-package migrateSyntax
-
-object ValueEtaExpansion {
-  val x = 1
-  val f: () => Int = () => x
-}

--- a/plugin/src/sbt-test/sbt-scala3-migrate/syntax-migration/src/main/scala/hello/MigrateSyntax.scala
+++ b/plugin/src/sbt-test/sbt-scala3-migrate/syntax-migration/src/main/scala/hello/MigrateSyntax.scala
@@ -13,20 +13,6 @@ object MigrateSyntaxTest {
     }
   }
 
-  //fix.scala213.ParensAroundLambda
-  val f = { x: Int => x * x }
-
-  //fix.scala213.ExplicitNonNullaryApply
-  trait Chunk {
-    def bytes(): Seq[Byte]
-
-    def toSeq: Seq[Byte] = bytes
-  }
-
-  //fix.scala213.ExplicitNullaryEtaExpansion
-  val x            = 1
-  val g: () => Int = x _
-
   //fix.scala213.Any2StringAdd
   val str = new AnyRef + "foo"
 }

--- a/plugin/src/sbt-test/sbt-scala3-migrate/syntax-migration/src/test/scala/hello/MigrateSyntaxTest.scala
+++ b/plugin/src/sbt-test/sbt-scala3-migrate/syntax-migration/src/test/scala/hello/MigrateSyntaxTest.scala
@@ -13,20 +13,6 @@ object MigrateSyntax {
     }
   }
 
-  //fix.scala213.ParensAroundLambda
-  val f = { x: Int => x * x }
-
-  //fix.scala213.ExplicitNonNullaryApply
-  trait Chunk {
-    def bytes(): Seq[Byte]
-
-    def toSeq: Seq[Byte] = bytes
-  }
-
-  //fix.scala213.ExplicitNullaryEtaExpansion
-  val x            = 1
-  val g: () => Int = x _
-
   //fix.scala213.Any2StringAdd
   val str = new AnyRef + "foo"
 }


### PR DESCRIPTION
…r rewrite

+ add Explicit result types that helps with the inference