### PR TITLE
Remove jsoniter-scala from the list of macro libraries

### DIFF
--- a/migrate/src/main/scala/migrate/internal/InitialLib.scala
+++ b/migrate/src/main/scala/migrate/internal/InitialLib.scala
@@ -192,7 +192,6 @@ object InitialLib {
       Organization("org.parboiled")                               -> Name("parboiled"),
       Organization("com.github.pureconfig")                       -> Name("pureconfig"),
       Organization("com.geirsson")                                -> Name("metaconfig-typesafe-config"),
-      Organization("com.github.plokhotnyuk.jsoniter-scala")       -> Name("jsoniter-scala-core"),
       Organization("com.thoughtworks.each")                       -> Name("each"),
       Organization("dev.zio")                                     -> Name("zio-macros-core"),
       Organization("com.michaelpollmeier")                        -> Name("macros")


### PR DESCRIPTION
The latest version of jsoniter-scala has Core and Macros APIs that are source compatible for 2.x and 3.x versions of Scala:
https://github.com/plokhotnyuk/jsoniter-scala/releases/tag/v2.12.1