### PR TITLE
Support Scala 2.13.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -204,19 +204,19 @@ addCommandAlias("compileScalafixOutputinScala3", s"""set `scalafix-output`/scala
 def isCI = System.getenv("CI") != null
 
 lazy val V = new {
-  val scala213              = "2.13.7"
+  val scala213              = "2.13.8"
   val scala213BinaryVersion = "2.13"
-  val scala212              = "2.12.14"
-  val scalatest             = "3.2.10"
-  val scala3                = "3.1.0"
-  val scalafix              = "0.9.33"
+  val scala212              = "2.12.15"
+  val scalatest             = "3.2.11"
+  val scala3                = "3.1.1"
+  val scalafix              = "0.9.34"
   val scribe                = "3.6.9"
   val organizeImports       = "0.4.3"
   val catsCore              = "2.7.0"
   val kindProjector         = "0.13.2"
   val coursierApi           = "2.0.16"
   val coursierInterface     = "1.0.6"
-  val scalameta             = "4.4.31"
+  val scalameta             = "4.4.32"
   val localSnapshotVersion  = "0.5.0-SNAPSHOT"
   val zio                   = "1.0.13"
 }

--- a/plugin/src/main/scala/migrate/Messages.scala
+++ b/plugin/src/main/scala/migrate/Messages.scala
@@ -8,7 +8,7 @@ private[migrate] object Messages {
        |
        |Your project must be in 2.13 and not in $scalaVersion
        |Please change the scalaVersion following this command
-       |set LocalProject("$projectId") / scalaVersion := "2.13.7"
+       |set LocalProject("$projectId") / scalaVersion := "2.13.8"
        |
        |
        |""".stripMargin

--- a/plugin/src/sbt-test/sbt-scala3-migrate/aggregate-project/build.sbt
+++ b/plugin/src/sbt-test/sbt-scala3-migrate/aggregate-project/build.sbt
@@ -1,15 +1,15 @@
-ThisBuild / scalaVersion := "2.13.7"
+ThisBuild / scalaVersion := "2.13.8"
 
 lazy val subproject = project
   .in(file("subproject"))
   .settings(TaskKey[Unit]("checkNotMigrated") := {
-    assert(scalaVersion.value == "2.13.7")
+    assert(scalaVersion.value == "2.13.8")
   })
 
 lazy val `aggregate-project` = project
   .in(file("."))
   .settings(TaskKey[Unit]("checkMigration") := {
-    assert(scalaVersion.value == "3.1.0", s"Wrong scala version ${scalaVersion.value}. Expected 3.1.0")
+    assert(scalaVersion.value == "3.1.1", s"Wrong scala version ${scalaVersion.value}. Expected 3.1.1")
     (Compile / compile).value
   })
   .aggregate(subproject)

--- a/plugin/src/sbt-test/sbt-scala3-migrate/integration-test/build.sbt
+++ b/plugin/src/sbt-test/sbt-scala3-migrate/integration-test/build.sbt
@@ -2,11 +2,11 @@ lazy val `integration-test` = project
   .in(file("integration-test"))
   .configs(IntegrationTest)
   .settings(
-    scalaVersion := "2.13.7",
+    scalaVersion := "2.13.8",
     // Enable migration on IntegrationTest config
     inConfig(IntegrationTest)(Defaults.itSettings ++ ScalaMigratePlugin.configSettings),
     TaskKey[Unit]("checkMigration") := {
-      assert(scalaVersion.value == "3.1.0")
+      assert(scalaVersion.value == "3.1.1")
       (IntegrationTest / compile).value
     }
   )

--- a/plugin/src/sbt-test/sbt-scala3-migrate/library-dependencies/build.sbt
+++ b/plugin/src/sbt-test/sbt-scala3-migrate/library-dependencies/build.sbt
@@ -13,13 +13,13 @@ lazy val `library-dependencies` = project
       else Seq(compilerPlugin("org.typelevel" % "kind-projector" % V.kindProjector cross CrossVersion.full))
     },
     TaskKey[Unit]("checkMigration") := {
-      assert(scalaVersion.value == "3.1.0", s"Wrong scala version ${scalaVersion.value}. Expected 3.1.0")
+      assert(scalaVersion.value == "3.1.1", s"Wrong scala version ${scalaVersion.value}. Expected 3.1.1")
       (Compile / compile).value
     }
   )
 
 lazy val V = new {
-  val scala213      = "2.13.7"
+  val scala213      = "2.13.8"
   val catsCore      = "2.7.0"
   val kindProjector = "0.13.2"
 }

--- a/plugin/src/sbt-test/sbt-scala3-migrate/managed-sources/build.sbt
+++ b/plugin/src/sbt-test/sbt-scala3-migrate/managed-sources/build.sbt
@@ -1,7 +1,7 @@
 lazy val `managed-sources` = project
   .in(file("."))
   .settings(
-    scalaVersion := "2.13.7",
+    scalaVersion := "2.13.8",
     Compile / sourceGenerators += Def.task {
       val file = (Compile / sourceManaged).value / "buildinfo" / "BuildInfo.scala"
       val buildInfo = s"""|
@@ -15,7 +15,7 @@ lazy val `managed-sources` = project
       Seq(file)
     },
     TaskKey[Unit]("checkMigration") := {
-      assert(scalaVersion.value == "3.1.0", s"Wrong scala version ${scalaVersion.value}. Expected 3.1.0")
+      assert(scalaVersion.value == "3.1.1", s"Wrong scala version ${scalaVersion.value}. Expected 3.1.1")
       (Compile / compile).value
     }
   )

--- a/plugin/src/sbt-test/sbt-scala3-migrate/scalac-options-migration/build.sbt
+++ b/plugin/src/sbt-test/sbt-scala3-migrate/scalac-options-migration/build.sbt
@@ -3,7 +3,7 @@ import migrate.ScalaMigratePlugin
 lazy val `scalac-options-migration` = project
   .in(file("."))
   .settings(
-    scalaVersion := "2.13.7",
+    scalaVersion := "2.13.8",
     scalacOptions ++= Seq(
       "-encoding",
       "UTF-8",

--- a/plugin/src/sbt-test/sbt-scala3-migrate/syntax-migration/build.sbt
+++ b/plugin/src/sbt-test/sbt-scala3-migrate/syntax-migration/build.sbt
@@ -1,3 +1,3 @@
 lazy val `syntax-migration` = project
   .in(file("."))
-  .settings(scalaVersion := "2.13.7")
+  .settings(scalaVersion := "2.13.8")

--- a/plugin/src/sbt-test/sbt-scala3-migrate/type-inference-migration/build.sbt
+++ b/plugin/src/sbt-test/sbt-scala3-migrate/type-inference-migration/build.sbt
@@ -1,9 +1,9 @@
 lazy val `type-inference-migration` = project
   .in(file("."))
   .settings(
-    scalaVersion := "2.13.7",
+    scalaVersion := "2.13.8",
     TaskKey[Unit]("checkMigration") := {
-      assert(scalaVersion.value == "3.1.0", s"Wrong scala version ${scalaVersion.value}. Expected 3.1.0")
+      assert(scalaVersion.value == "3.1.1", s"Wrong scala version ${scalaVersion.value}. Expected 3.1.1")
       (Test / compile).value
     }
   )

--- a/plugin/src/sbt-test/sbt-scala3-migrate/unresolved-dependencies/build.sbt
+++ b/plugin/src/sbt-test/sbt-scala3-migrate/unresolved-dependencies/build.sbt
@@ -12,7 +12,7 @@ lazy val `unresolved-dependencies` = project
   )
 
 lazy val V = new {
-  val scala213      = "2.13.7"
+  val scala213      = "2.13.8"
   val catsCore      = "2.7.0"
   val kindProjector = "0.13.2"
 }

--- a/scalafix/output/src/main/scala/incompat/Cats1.scala
+++ b/scalafix/output/src/main/scala/incompat/Cats1.scala
@@ -92,7 +92,7 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
    * `F[A]` values.
    */
   def recover[A](fa: F[A])(pf: PartialFunction[E, A]): F[A] =
-    handleErrorWith[A](fa)(e => (pf.andThen[F[A]](pure[A] _)).applyOrElse(e, raiseError[A] _))
+    handleErrorWith[A](fa)(e => (pf.andThen[F[A]](pure[A] _)).applyOrElse[E, F[A]](e, raiseError[A] _))
 
   /**
    * Recover from certain errors by mapping them to an `F[A]` value.
@@ -192,7 +192,7 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
    * }}}
    */
   def onError[A](fa: F[A])(pf: PartialFunction[E, F[Unit]]): F[A] =
-    handleErrorWith[A](fa)(e => (pf.andThen[F[A]](map2[Unit, A, A](_, raiseError[A](e))((_, b) => b))).applyOrElse(e, raiseError[A]))
+    handleErrorWith[A](fa)(e => (pf.andThen[F[A]](map2[Unit, A, A](_, raiseError[A](e))((_, b) => b))).applyOrElse[E, F[A]](e, raiseError[A]))
 
   /**
    * Often E is Throwable. Here we try to call pure or catch


### PR DESCRIPTION
It is currently not possible to use the plugin with Scala `2.13.8`, since `semanticdb-scalac` version `4.4.31` does not support Scala `2.13.8`