### PR TITLE
Fix parens around lambda

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -218,6 +218,6 @@ lazy val V = new {
   val coursierApi           = "2.0.16"
   val coursierInterface     = "1.0.19"
   val scalameta             = "4.8.8"
-  val localSnapshotVersion  = "0.6.0-SNAPSHOT"
+  val localSnapshotVersion  = "0.7.0-SNAPSHOT"
   val zio                   = "1.0.14"
 }

--- a/build.sbt
+++ b/build.sbt
@@ -213,7 +213,6 @@ lazy val V = new {
   val scalatest             = "3.2.17"
   val scala3                = "3.3.1"
   val scalafix              = "0.11.0"
-  val organizeImports       = "0.4.3"
   val catsCore              = "2.10.0"
   val kindProjector         = "0.13.2"
   val coursierApi           = "2.0.16"

--- a/migrate/src/main/scala/migrate/utils/ScalafixService.scala
+++ b/migrate/src/main/scala/migrate/utils/ScalafixService.scala
@@ -74,7 +74,7 @@ object ScalafixService {
   val fixSyntaxRules: Seq[String] = Seq(
     "ProcedureSyntax",
     "fix.scala213.ExplicitNullaryEtaExpansion",
-    "fix.scala213.ParensAroundLambda",
+    "migrate.ParensAroundParam",
     "fix.scala213.ExplicitNonNullaryApply",
     "fix.scala213.Any2StringAdd",
     "ExplicitResultTypes"
@@ -102,9 +102,8 @@ object ScalafixService {
 
   private def getClassPathforRewriteRules(): Try[Classpath] =
     Try {
-      val paths1 = downloadDependecies(dep"org.scala-lang:scala-rewrites_2.13:0.1.5")
-      val paths2 = downloadDependecies(dep"com.sandinh:scala-rewrites_2.13:1.1.0-M1")
-      Classpath((paths1 ++ paths2): _*)
+      val jars = downloadDependecies(dep"org.scala-lang:scala-rewrites_2.13:0.1.5")
+      Classpath(jars: _*)
     }
 
   private def getClassPathforMigrateRules(): Try[Classpath] = {

--- a/plugin/src/sbt-test/sbt-scala3-migrate/integration-test/integration-test/src/it/scala/hello/WrongSyntax.scala
+++ b/plugin/src/sbt-test/sbt-scala3-migrate/integration-test/integration-test/src/it/scala/hello/WrongSyntax.scala
@@ -13,8 +13,10 @@ object WrongSyntax {
     }
   }
 
-  // fix.scala213.ParensAroundLambda
-  val f = { x: Int => x * x }
+  // migrate.ParensAroundParam
+  val f1 = { x: Int => x * x }
+  val f2 = { (x: Int) => x * x }
+  val f3 = (x: Int) => x * x
 
   // fix.scala213.ExplicitNonNullaryApply
   trait Chunk {

--- a/plugin/src/sbt-test/sbt-scala3-migrate/syntax-migration/src/main/scala/hello/MigrateSyntax.scala
+++ b/plugin/src/sbt-test/sbt-scala3-migrate/syntax-migration/src/main/scala/hello/MigrateSyntax.scala
@@ -16,7 +16,7 @@ object MigrateSyntaxTest {
   // migrate.ParensAroundParam
   val f1 = { x: Int => x * x }
   val f2 = { (x: Int) => x * x }
-  val f3  = (x: Int) => x * x
+  val f3 = (x: Int) => x * x
 
   // fix.scala213.ExplicitNonNullaryApply
   trait Chunk {

--- a/plugin/src/sbt-test/sbt-scala3-migrate/syntax-migration/src/main/scala/hello/MigrateSyntax.scala
+++ b/plugin/src/sbt-test/sbt-scala3-migrate/syntax-migration/src/main/scala/hello/MigrateSyntax.scala
@@ -13,8 +13,10 @@ object MigrateSyntaxTest {
     }
   }
 
-  // fix.scala213.ParensAroundLambda
-  val f = { x: Int => x * x }
+  // migrate.ParensAroundParam
+  val f1 = { x: Int => x * x }
+  val f2 = { (x: Int) => x * x }
+  val f3  = (x: Int) => x * x
 
   // fix.scala213.ExplicitNonNullaryApply
   trait Chunk {

--- a/plugin/src/sbt-test/sbt-scala3-migrate/syntax-migration/src/test/scala/hello/MigrateSyntaxTest.scala
+++ b/plugin/src/sbt-test/sbt-scala3-migrate/syntax-migration/src/test/scala/hello/MigrateSyntaxTest.scala
@@ -13,8 +13,10 @@ object MigrateSyntax {
     }
   }
 
-  // fix.scala213.ParensAroundLambda
-  val f = { x: Int => x * x }
+  // migrate.ParensAroundParam
+  val f1 = { x: Int => x * x }
+  val f2 = { (x: Int) => x * x }
+  val f3 = (x: Int) => x * x
 
   // fix.scala213.ExplicitNonNullaryApply
   trait Chunk {

--- a/scalafix/input/src/main/scala/parensaroundparam/ParensAroundParam.scala
+++ b/scalafix/input/src/main/scala/parensaroundparam/ParensAroundParam.scala
@@ -1,0 +1,22 @@
+/*
+rule = migrate.ParensAroundParam
+*/
+package parensaroundparam
+
+// taken from https://github.com/ohze/scala-rewrites/blob/dotty/input/src/test/scala/fix/scala213/ParensAroundLambda.scala
+class ParensAroundParam {
+  Nil.foreach { x: Nothing => }
+  Nil.foreach { (x: Nothing) => }
+  val f = { s: String => s }
+  val g = (s: String) => ()
+  Map("a" -> 1).map { x: (String, Int) =>
+    ???
+  }
+
+  Seq(1).map { i: Int =>
+    i + 1
+  }
+  Seq(1).map { i => i + 1 }
+
+  Seq(1).foreach { implicit i: Int => }
+}

--- a/scalafix/output/src/main/scala/parensaroundparam/ParensAroundParam.scala
+++ b/scalafix/output/src/main/scala/parensaroundparam/ParensAroundParam.scala
@@ -1,0 +1,19 @@
+package parensaroundparam
+
+// taken from https://github.com/ohze/scala-rewrites/blob/dotty/input/src/test/scala/fix/scala213/ParensAroundLambda.scala
+class ParensAroundParam {
+  Nil.foreach { (x: Nothing) => }
+  Nil.foreach { (x: Nothing) => }
+  val f = { (s: String) => s }
+  val g = (s: String) => ()
+  Map("a" -> 1).map { (x: (String, Int)) =>
+    ???
+  }
+
+  Seq(1).map { (i: Int) =>
+    i + 1
+  }
+  Seq(1).map { i => i + 1 }
+
+  Seq(1).foreach { implicit i: Int => }
+}

--- a/scalafix/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/scalafix/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,1 +1,2 @@
 migrate.MigrateRule
+migrate.ParensAroundParam

--- a/scalafix/rules/src/main/scala/migrate/ParensAroundParam.scala
+++ b/scalafix/rules/src/main/scala/migrate/ParensAroundParam.scala
@@ -1,0 +1,18 @@
+package migrate
+
+import scala.meta._
+import scala.meta.tokens.Token._
+
+import scalafix.v1._
+
+// taken from https://github.com/ohze/scala-rewrites/blob/dotty/rewrites/src/main/scala/fix/scala213/ParensAroundLambda.scala
+class ParensAroundParam extends SyntacticRule("migrate.ParensAroundParam") {
+  override def fix(implicit doc: SyntacticDocument): Patch =
+    doc.tree.collect { case fun @ Term.Function(List(param @ Term.Param(_, _, Some(_), _)), _) =>
+      fun.tokens.head match {
+        case _: LeftParen  => Patch.empty
+        case _: KwImplicit => Patch.empty
+        case _             => Patch.addAround(param, "(", ")")
+      }
+    }.asPatch
+}


### PR DESCRIPTION
Remove dependency to com.sandinh:scala-rewrites and fix parens around lambda.

Before the fix it used to add unnecessary parens around parens:
```diff
- { (i: Int) => i + 1 }
+ { ((i: Int)) => i + 1 }
```