### PR TITLE
Fixed typo for unknown scalac options.

### DIFF
--- a/plugin/src/main/scala/migrate/ScalacOptionsMigration.scala
+++ b/plugin/src/main/scala/migrate/ScalacOptionsMigration.scala
@@ -87,7 +87,7 @@ private[migrate] object ScalacOptionsMigration {
 
   private def unknownMessage(scalacOptions: Seq[String]): String =
     s"""|
-        |$YELLOW${BOLD}Unknonw scalacOptions:$RESET
+        |$YELLOW${BOLD}Unknown scalacOptions:$RESET
         |${scalacOptions.mkString("\n")}
         |""".stripMargin
 }


### PR DESCRIPTION
The word "Unknonw" has been replaced with "Unknown", when referring to unidentified scalac options.