### PR TITLE
Use configured repositories from the sbt build

### DIFF
--- a/interfaces/migrate/src/main/java/migrate/interfaces/Migrate.java
+++ b/interfaces/migrate/src/main/java/migrate/interfaces/Migrate.java
@@ -28,7 +28,7 @@ public interface Migrate {
                  Path baseDirectory);
     
     MigratedScalacOptions migrateScalacOption(List<String> scala3CompilerOptions);
-    MigratedLibs migrateLibs(List<Lib> libs);
+    MigratedLibs migrateLibs(List<Lib> libs, List<String> repositories);
 
     void migrateSyntax(List<Path> unmanagedSources,
                        Path targetRoot,

--- a/migrate/src/main/scala/migrate/interfaces/MigrateImpl.scala
+++ b/migrate/src/main/scala/migrate/interfaces/MigrateImpl.scala
@@ -11,6 +11,7 @@ import migrate.ScalacOptionsMigration
 import migrate.internal.AbsolutePath
 import migrate.internal.Classpath
 import migrate.internal.InitialLib
+import migrate.internal.Repository
 import migrate.utils.ScalaExtensions._
 import migrate.utils.ScalafixService
 
@@ -58,9 +59,10 @@ final class MigrateImpl(logger: Logger) extends Migrate {
   override def migrateScalacOption(scalacOptions: jutil.List[String]): MigratedScalacOptions =
     ScalacOptionsMigration.migrate(scalacOptions.asScala.toSeq)
 
-  override def migrateLibs(libs: jutil.List[Lib]): MigratedLibs = {
-    val initialLibs = libs.asScala.map(InitialLib.apply).toSeq
-    LibraryMigration.migrateLibs(initialLibs)
+  override def migrateLibs(libs: jutil.List[Lib], repositories: jutil.List[String]): MigratedLibs = {
+    val initialLibs  = libs.asScala.map(InitialLib.apply).toSeq
+    val initialRepos = repositories.asScala.map(Repository).toSeq
+    LibraryMigration.migrateLibs(initialLibs, initialRepos)
   }
 
   override def migrateSyntax(

--- a/migrate/src/main/scala/migrate/internal/Repository.scala
+++ b/migrate/src/main/scala/migrate/internal/Repository.scala
@@ -1,0 +1,3 @@
+package migrate.internal
+
+case class Repository(url: String)

--- a/migrate/src/test/scala/migrate/LibraryMigrationSuite.scala
+++ b/migrate/src/test/scala/migrate/LibraryMigrationSuite.scala
@@ -2,10 +2,12 @@ package migrate
 
 import scala.Console._
 
+import coursier.Repositories
 import migrate.internal.CrossCompatibleLibrary
 import migrate.internal.CrossVersion
 import migrate.internal.IncompatibleLibrary
 import migrate.internal.InitialLib
+import migrate.internal.Repository
 import migrate.internal.UpdatedVersion
 import migrate.internal.ValidLibrary
 import org.scalatest.funsuite.AnyFunSuiteLike
@@ -16,6 +18,7 @@ class LibraryMigrationSuite extends AnyFunSuiteLike {
   val fullJvm: CrossVersion.Full     = CrossVersion.Full("", "")
   val pluginConfig: Some[String]     = Some("plugin->default(compile)")
 
+  val akka: InitialLib             = InitialLib("com.typesafe.akka:akka-actor:2.9.4", binaryJvm)
   val cats: InitialLib             = InitialLib("org.typelevel:cats-core:2.4.0", binaryJvm)
   val cats213: InitialLib          = InitialLib("org.typelevel:cats-core_2.13:2.4.0", CrossVersion.Disabled)
   val opentelemetry: InitialLib    = InitialLib("io.opentelemetry:opentelemetry-api:0.7.1", CrossVersion.Disabled)
@@ -31,8 +34,10 @@ class LibraryMigrationSuite extends AnyFunSuiteLike {
   val domtypes: InitialLib    = InitialLib("com.raquo:domtypes:0.14.3", binaryJs)
   val domutils: InitialLib    = InitialLib("com.raquo:domtestutils:0.14.7", binaryJs)
 
+  val defaultRepositories: Seq[Repository] = Seq(Repository(Repositories.central.root))
+
   test("Integrated compiler plugin: kind projector") {
-    val migrated  = LibraryMigration.migrateLib(kindProjector)
+    val migrated  = LibraryMigration.migrateLib(kindProjector, defaultRepositories)
     val formatted = migrated.formatted
     val expected =
       s"""addCompilerPlugin(("org.typelevel" %% "kind-projector" % "0.12.0").cross(CrossVersion.full))""" +
@@ -42,52 +47,65 @@ class LibraryMigrationSuite extends AnyFunSuiteLike {
   }
 
   test("Incompatible compiler plugin: better monadic for") {
-    val migrated  = LibraryMigration.migrateLib(betterMonadicFor)
+    val migrated  = LibraryMigration.migrateLib(betterMonadicFor, defaultRepositories)
     val formatted = migrated.formatted
     val expected  = s"""addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1") $RED(Compiler Plugin)$RESET"""
     assert(formatted == expected)
   }
 
   test("Java lib") {
-    val migrated = LibraryMigration.migrateLib(opentelemetry)
+    val migrated = LibraryMigration.migrateLib(opentelemetry, defaultRepositories)
     val expected = ValidLibrary(opentelemetry)
     assert(migrated == expected)
   }
 
   test("Java lib 2") {
-    val migrated = LibraryMigration.migrateLib(javaLib2)
+    val migrated = LibraryMigration.migrateLib(javaLib2, defaultRepositories)
     val expected = ValidLibrary(javaLib2)
     assert(migrated == expected)
   }
 
   test("Available in scala 3") {
-    val migrated = LibraryMigration.migrateLib(cats)
+    val migrated = LibraryMigration.migrateLib(cats, defaultRepositories)
     assert(migrated.isInstanceOf[UpdatedVersion])
     val version = migrated.asInstanceOf[UpdatedVersion].versions
     assert(version.head.toString == "2.6.1")
   }
 
+  test("only available in an earlier version in maven central repository") {
+    val migrated = LibraryMigration.migrateLib(akka, defaultRepositories)
+    assert(migrated.isInstanceOf[UpdatedVersion])
+    val versions = migrated.asInstanceOf[UpdatedVersion].versions
+    assert(versions.last == "2.9.0-M2", "The last version published to Maven Central was 2.9.0-M2")
+  }
+
+  test("available in scala 3 in another repository") {
+    val repositories = defaultRepositories :+ Repository("https://repo.akka.io/maven")
+    val migrated     = LibraryMigration.migrateLib(akka, repositories)
+    assert(migrated.isInstanceOf[ValidLibrary])
+  }
+
   test("CrossVersion.Disabled to CrossVersion.Binary") {
-    val migrated = LibraryMigration.migrateLib(cats213)
+    val migrated = LibraryMigration.migrateLib(cats213, defaultRepositories)
     assert(migrated.isInstanceOf[UpdatedVersion])
     val updatedVersion = migrated.asInstanceOf[UpdatedVersion]
     assert(updatedVersion.versions.head.toString == "2.6.1")
     assert(updatedVersion.lib == cats)
   }
   test("Don't show older version") {
-    val migrated = LibraryMigration.migrateLib(collectionCompat)
+    val migrated = LibraryMigration.migrateLib(collectionCompat, defaultRepositories)
     assert(migrated.isInstanceOf[UpdatedVersion])
     val updatedVersions = migrated.asInstanceOf[UpdatedVersion].versions
     assert(!updatedVersions.contains("2.3.2"))
   }
   test("Cross compatible lib") {
-    val migrated = LibraryMigration.migrateLib(scalafix)
+    val migrated = LibraryMigration.migrateLib(scalafix, defaultRepositories)
     val expected = CrossCompatibleLibrary(scalafix)
     assert(migrated == expected)
   }
   // Warning: this test may change if the lib is ported to scala 3
   test("Incompatible because macro lib") {
-    val migrated = LibraryMigration.migrateLib(macroLib)
+    val migrated = LibraryMigration.migrateLib(macroLib, defaultRepositories)
     val expected = IncompatibleLibrary(macroLib, "Macro Library")
     assert(migrated == expected)
   }
@@ -95,7 +113,7 @@ class LibraryMigrationSuite extends AnyFunSuiteLike {
   test("Filtered out libs") {
     val scalaLib     = InitialLib("org.scala-lang:scala-library:2.13.13", CrossVersion.Disabled)
     val scalajs      = InitialLib("org.scala-js:scalajs-compiler:1.5.0", CrossVersion.Disabled)
-    val migratedLibs = LibraryMigration.migrateLibs(Seq(scalaLib, scalajs))
+    val migratedLibs = LibraryMigration.migrateLibs(Seq(scalaLib, scalajs), defaultRepositories)
     assert(migratedLibs.getValidLibraries.isEmpty)
     assert(migratedLibs.getUpdatedVersions.isEmpty)
     assert(migratedLibs.getCrossCompatibleLibraries.isEmpty)
@@ -112,7 +130,7 @@ class LibraryMigrationSuite extends AnyFunSuiteLike {
   }
 
   test("Formatting of valid Scala.js library") {
-    val migratedLib = LibraryMigration.migrateLib(domtypes)
+    val migratedLib = LibraryMigration.migrateLib(domtypes, defaultRepositories)
     val formatted   = migratedLib.formatted
     val expected    = s""""com.raquo" %%% "domtypes" % "0.14.3""""
     assert(formatted == expected)


### PR DESCRIPTION
The scala3 migration plugin gave a false suggestion for how to migrate Akka libraries. Instead of saying that the latest 2.9.4 version was a valid scala 3 library it suggested to downgrade to a version as early as 2.6.18 up to the version 2.9.0-M2. These version are the ones that are published to the maven central that this plugin are hard coded to. Later version of akka are published to https://repo.akka.io/maven.

This patch is using the configured repository in the sbt build to resolve the dependencies and are thereby able to find the correct versions.

Now:
```
sbt:test-project>  migrateDependencies test-project
[info]
[info] Starting migration of libraries and compiler plugins in project 'test-project'
[info]
[info] Valid dependencies:
...
[info] "com.typesafe.akka" %% "akka-cluster-typed" % "2.9.4"
...
```

Before this commit, older akka versions published to maven central was suggested by the migration tool
```
[warn] Versions to update:
...
[warn] "com.typesafe.akka" %% "akka-cluster-typed" % "2.6.17" (Other versions: 2.6.18, ..., 2.9.0-M2)
...

```


Will close #95 