### PR TITLE
Fix for MatchError when input is Vector

### DIFF
--- a/plugin/src/main/scala/migrate/internal/MigratedLib.scala
+++ b/plugin/src/main/scala/migrate/internal/MigratedLib.scala
@@ -27,7 +27,7 @@ case class UpdatedVersion(
       lib.configurations) + otherVersions
 
   private def otherVersions: String =
-    versions.tail match {
+    versions.tail.toList match {
       case Nil                 => ""
       case head :: Nil         => s" $YELLOW(Other version: $head)$RESET"
       case head :: last :: Nil => s" $YELLOW(Other versions: $head, $last)$RESET"


### PR DESCRIPTION
Fix for 
```
[error] scala.MatchError: Vector(3.1.0, 3.1.1, 3.1.2, 3.1.3, 3.1.4) (of class scala.collection.immutable.Vector)
[error] 	at migrate.internal.UpdatedVersion.otherVersions(MigratedLib.scala:30)
[error] 	at migrate.internal.UpdatedVersion.formatted(MigratedLib.scala:27)
[error] 	at migrate.LibsMigration$.$anonfun$updatedVersionsMessage$1(LibsMigration.scala:83)
[error] 	at scala.collection.immutable.List.map(List.scala:293)
[error] 	at migrate.LibsMigration$.updatedVersionsMessage(LibsMigration.scala:83)
[error] 	at migrate.LibsMigration$.$anonfun$internalImpl$5(LibsMigration.scala:43)
[error] 	at sbt.util.LoggerContext$LoggerContextImpl$Log.log(LoggerContext.scala:124)
[error] 	at sbt.internal.util.ManagedLogger.log(ManagedLogger.scala:42)
[error] 	at sbt.util.Logger.warn(Logger.scala:28)
```